### PR TITLE
Added CDI producer for CacheKeyGenerator and CacheResolverFactory.

### DIFF
--- a/cache-annotations-ri/cache-annotations-ri-cdi/src/main/java/org/jsr107/ri/annotations/cdi/CacheKeyGeneratorProducer.java
+++ b/cache-annotations-ri/cache-annotations-ri-cdi/src/main/java/org/jsr107/ri/annotations/cdi/CacheKeyGeneratorProducer.java
@@ -1,0 +1,41 @@
+/**
+ *  Copyright 2011-2013 Terracotta, Inc.
+ *  Copyright 2011-2013 Oracle America Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jsr107.ri.annotations.cdi;
+
+import javax.cache.annotation.CacheKeyGenerator;
+import javax.enterprise.inject.Produces;
+
+import org.jsr107.ri.annotations.DefaultCacheKeyGenerator;
+
+/**
+ * Producer for the default {@link javax.cache.annotation.CacheKeyGenerator}.
+ *
+ * @author Sven Haberer
+ * @since 1.0.0-injectability-improvement
+ */
+public class CacheKeyGeneratorProducer {
+  /**
+   * Produces a new instance of the {@link org.jsr107.ri.annotations.DefaultCacheKeyGenerator}.
+   *
+   * @return A new instance of the {@link org.jsr107.ri.annotations.DefaultCacheKeyGenerator}.
+   */
+  @Produces
+  @UsedByDefault
+  public CacheKeyGenerator produce() {
+    return new DefaultCacheKeyGenerator();
+  }
+}

--- a/cache-annotations-ri/cache-annotations-ri-cdi/src/main/java/org/jsr107/ri/annotations/cdi/CacheLookupUtil.java
+++ b/cache-annotations-ri/cache-annotations-ri-cdi/src/main/java/org/jsr107/ri/annotations/cdi/CacheLookupUtil.java
@@ -17,8 +17,6 @@
 package org.jsr107.ri.annotations.cdi;
 
 import org.jsr107.ri.annotations.AbstractCacheLookupUtil;
-import org.jsr107.ri.annotations.DefaultCacheKeyGenerator;
-import org.jsr107.ri.annotations.DefaultCacheResolverFactory;
 import org.jsr107.ri.annotations.InternalCacheInvocationContext;
 import org.jsr107.ri.annotations.InternalCacheKeyInvocationContext;
 import org.jsr107.ri.annotations.StaticCacheInvocationContext;
@@ -41,9 +39,13 @@ public class CacheLookupUtil extends AbstractCacheLookupUtil<InvocationContext> 
   @Inject
   private BeanManagerUtil beanManagerUtil;
 
-  private CacheKeyGenerator defaultCacheKeyGenerator = new DefaultCacheKeyGenerator();
-  private CacheResolverFactory defaultCacheResolverFactory = new DefaultCacheResolverFactory();
+  @Inject
+  @UsedByDefault
+  private CacheKeyGenerator defaultCacheKeyGenerator;
 
+  @Inject
+  @UsedByDefault
+  private CacheResolverFactory defaultCacheResolverFactory;
 
   /*
    * Annoation type cannot be known at compile time so ignore the warning

--- a/cache-annotations-ri/cache-annotations-ri-cdi/src/main/java/org/jsr107/ri/annotations/cdi/CacheResolverFactoryProducer.java
+++ b/cache-annotations-ri/cache-annotations-ri-cdi/src/main/java/org/jsr107/ri/annotations/cdi/CacheResolverFactoryProducer.java
@@ -1,0 +1,41 @@
+/**
+ *  Copyright 2011-2013 Terracotta, Inc.
+ *  Copyright 2011-2013 Oracle America Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jsr107.ri.annotations.cdi;
+
+import javax.cache.annotation.CacheResolverFactory;
+import javax.enterprise.inject.Produces;
+
+import org.jsr107.ri.annotations.DefaultCacheResolverFactory;
+
+/**
+ * Producer for the default {@link javax.cache.annotation.CacheResolverFactory}.
+ *
+ * @author Sven Haberer
+ * @since 1.0.0-injectability-improvement
+ */
+public class CacheResolverFactoryProducer {
+  /**
+   * Produces a new instance of the {@link org.jsr107.ri.annotations.DefaultCacheResolverFactory}.
+   *
+   * @return A new instance of the {@link org.jsr107.ri.annotations.DefaultCacheResolverFactory}.
+   */
+  @Produces
+  @UsedByDefault
+  public CacheResolverFactory produce() {
+    return new DefaultCacheResolverFactory();
+  }
+}

--- a/cache-annotations-ri/cache-annotations-ri-cdi/src/main/java/org/jsr107/ri/annotations/cdi/UsedByDefault.java
+++ b/cache-annotations-ri/cache-annotations-ri-cdi/src/main/java/org/jsr107/ri/annotations/cdi/UsedByDefault.java
@@ -1,0 +1,43 @@
+/**
+ *  Copyright 2011-2013 Terracotta, Inc.
+ *  Copyright 2011-2013 Oracle America Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jsr107.ri.annotations.cdi;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+/**
+ * Qualifies the default implementation of {@link javax.cache.annotation.CacheKeyGenerator} and {@link
+ * javax.cache.annotation.CacheResolverFactory}. This is necessary, to avoid ambiguity with custom implementations which
+ * have to be {@link javax.enterprise.inject.Default}, so that the {@link org.jsr107.ri.annotations.cdi.BeanManagerUtil}
+ * is able to resolve them.
+ *
+ * @author Sven Haberer
+ * @since 1.0.0-injectability-improvement2
+ */
+@Qualifier
+@Retention(RUNTIME)
+@Target({ TYPE, METHOD, FIELD, PARAMETER })
+public @interface UsedByDefault {
+}


### PR DESCRIPTION
That way, an application can override either of them.

Note that they are qualified with `@UsedByDefault` as any custom implementation has be be `@Default` for the `BeanManagerUtil` being able to resolve it.